### PR TITLE
aconfig: Disable enroll_layout_truncate_improvement

### DIFF
--- a/aconfig/bp2a/com.android.settings.flags/enroll_layout_truncate_improvement_flag_values.textproto
+++ b/aconfig/bp2a/com.android.settings.flags/enroll_layout_truncate_improvement_flag_values.textproto
@@ -1,6 +1,6 @@
 flag_value {
   package: "com.android.settings.flags"
   name: "enroll_layout_truncate_improvement"
-  state: ENABLED
+  state: DISABLED
   permission: READ_ONLY
 }


### PR DESCRIPTION
Breaks fingeprint enrollment layout on devices having udfps too low on screen.